### PR TITLE
Reorder changes to ejabberd.cfg

### DIFF
--- a/README
+++ b/README
@@ -197,10 +197,10 @@ changes:
 {hosts, ["localhost", "private.localhost", "public.localhost"]}.
 ---------------------------------------------------------------------------
 +
-  b. Comment out the `mod_offline` directive
-  c. Increase the `max_user_sessions` value to 10000
-  d. Change all `max_stanza_size` values to 2000000
-  e. Change all `maxrate` values to 500000 
+  b. Change all `max_stanza_size` values to 2000000
+  c. Change all `maxrate` values to 500000
+  d. Increase the `max_user_sessions` value to 10000
+  e. Comment out the `mod_offline` directive
 +
 3. Restart the ejabberd server to make the changes take effect:
 +


### PR DESCRIPTION
I found it annoying that the list of changes to make to ejabberd.cfg didn't follow the order that the options showed up in the default Debian ejabberd.cfg.  I reordered them so after you finish changing one option, you can search forward in the document for the next term.
