### PR TITLE
Use location.hostname to assemble websocket path

### DIFF
--- a/src/javascript/opensrf_ws.js.in
+++ b/src/javascript/opensrf_ws.js.in
@@ -53,7 +53,7 @@ OpenSRF.WebSocket.prototype.send = function(message) {
 
     // we have no websocket or an invalid websocket.  build a new one.
 
-    var path = 'wss://' + location.host + ':' + 
+    var path = 'wss://' + location.hostname + ':' + 
         WEBSOCKET_PORT_SSL + WEBSOCKET_URL_PATH;
 
     console.debug('connecting websocket to ' + path);


### PR DESCRIPTION
opensrf_ws.js.in builds opensrf_ws.js which does some string-mangling to
infer the websocket path from the domain name of the server, and a port
constant defined at install time.  If the webserver providing
opensrf_ws.js is running on an alternate port (eg. not http://.*:80 or
https://.*:443), then location.host will include that port.  The
previous code would transform example.org:4443 into the following
invalid URL: wss://example.org:4443:7682/osrf-websocket-translator

Using location.hostname should provide more consistent results; it is
always just the domain name (never the port).